### PR TITLE
github/workflows: add attest step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       contents: write
       id-token: write
       packages: write
+      attestations: write
     env:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
@@ -68,3 +69,13 @@ jobs:
           args: "release --clean"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Attest release artifacts"
+        uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.txt
+            dist/*.pem
+            dist/*.sig

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,13 +36,13 @@ builds:
         goarch: "arm"
 
 archives:
-  - format: "tar.gz"
+  - formats: "tar.gz"
     wrap_in_directory: true
     name_template: >-
       {{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: "windows"
-        format: "zip"
+        formats: "zip"
     files:
       - "README*"
       - "LICENSE*"


### PR DESCRIPTION
Fix deprecation warnings from GoReleaser and add attest step to the release workflow.